### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ let sortDirection = 1;
 
 // Tracker will unsubscribe when the Svelte component is destroyed
 $m: sub = Meteor.subscribe('todos');
-$m: subReady = sub?.ready();
+$m: subReady = sub.ready();
 
 // This will rerun whenever the documents are updated or sortDirection is changed
 $m: todos = Todos.find({}, { sort: { createdAt: sortDirection}}).fetch()

--- a/README.md
+++ b/README.md
@@ -49,13 +49,10 @@ Example:
 const Todos = new Mongo.Collection('todos');
 
 let sortDirection = 1;
-let subReady = false;
 
 // Tracker will unsubscribe when the Svelte component is destroyed
-$m: {
-  let sub = Meteor.subscribe('todos');
-  subReady = sub.ready();
-}
+$m: sub = Meteor.subscribe('todos');
+$m: subReady = sub?.ready();
 
 // This will rerun whenever the documents are updated or sortDirection is changed
 $m: todos = Todos.find({}, { sort: { createdAt: sortDirection}}).fetch()


### PR DESCRIPTION
Small change to recommend moving `sub.ready` into its own `$m` statement. Having it in the same `$m` as the subscription causes `Meteor.subscribe` to be called multiple times which I think is harmless but feels unnecessary.